### PR TITLE
Phase 3: tooling, migration diff, cache, and enhanced JSDoc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ proc-macro2 = "1.0"
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sha2 = "0.10"
 
 # CLI
 clap = { version = "4.4", features = ["derive"] }
@@ -48,4 +49,5 @@ anyhow = "1.0"
 
 # Testing
 pretty_assertions = "1.4"
+proptest = "1.4"
 strum = { version = "0.28", features = ["derive"] }

--- a/crates/gear-mesh-generator/Cargo.toml
+++ b/crates/gear-mesh-generator/Cargo.toml
@@ -18,3 +18,5 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
+proptest = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/gear-mesh-generator/src/lib.rs
+++ b/crates/gear-mesh-generator/src/lib.rs
@@ -3,14 +3,15 @@
 //! This crate provides TypeScript code generation from Rust types
 //! and serves as the main entry point for the gear-mesh library.
 
+use std::fmt;
+use std::path::PathBuf;
+use std::sync::Arc;
+
 mod branded;
 mod module_organizer;
 mod typescript;
 pub mod utils;
 mod validation_gen;
-
-use std::fmt;
-use std::sync::Arc;
 
 #[cfg(test)]
 mod tests;
@@ -95,6 +96,8 @@ pub struct GeneratorConfig {
     pub generate_zod: bool,
     /// JSDocを生成するか
     pub generate_jsdoc: bool,
+    /// 詳細なJSDocタグを追加するか
+    pub enhanced_jsdoc: bool,
     /// `Option<T>` の出力スタイル
     pub option_style: OptionStyle,
     /// `Result<T, E>` の出力スタイル
@@ -103,6 +106,10 @@ pub struct GeneratorConfig {
     pub module_strategy: ModuleStrategy,
     /// カスタム型変換プラグイン
     pub transformers: Vec<Arc<dyn TypeTransformer>>,
+    /// インクリメンタルキャッシュを有効にするか
+    pub enable_cache: bool,
+    /// キャッシュディレクトリ
+    pub cache_dir: PathBuf,
     /// インデント文字列
     pub indent: String,
 }
@@ -115,10 +122,13 @@ impl fmt::Debug for GeneratorConfig {
             .field("generate_validation", &self.generate_validation)
             .field("generate_zod", &self.generate_zod)
             .field("generate_jsdoc", &self.generate_jsdoc)
+            .field("enhanced_jsdoc", &self.enhanced_jsdoc)
             .field("option_style", &self.option_style)
             .field("result_style", &self.result_style)
             .field("module_strategy", &self.module_strategy)
             .field("transformers", &self.transformers.len())
+            .field("enable_cache", &self.enable_cache)
+            .field("cache_dir", &self.cache_dir)
             .field("indent", &self.indent)
             .finish()
     }
@@ -138,10 +148,13 @@ impl GeneratorConfig {
             generate_validation: false,
             generate_zod: false,
             generate_jsdoc: true,
+            enhanced_jsdoc: false,
             option_style: OptionStyle::Nullable,
             result_style: ResultStyle::OkOnly,
             module_strategy: ModuleStrategy::SingleFile,
             transformers: Vec::new(),
+            enable_cache: false,
+            cache_dir: PathBuf::from(".gear-mesh-cache"),
             indent: "    ".to_string(),
         }
     }
@@ -171,6 +184,11 @@ impl GeneratorConfig {
         self
     }
 
+    pub fn with_enhanced_jsdoc(mut self, enabled: bool) -> Self {
+        self.enhanced_jsdoc = enabled;
+        self
+    }
+
     pub fn with_option_style(mut self, option_style: OptionStyle) -> Self {
         self.option_style = option_style;
         self
@@ -196,6 +214,16 @@ impl GeneratorConfig {
 
     pub fn with_transformer_arc(mut self, transformer: Arc<dyn TypeTransformer>) -> Self {
         self.transformers.push(transformer);
+        self
+    }
+
+    pub fn with_cache(mut self, enabled: bool) -> Self {
+        self.enable_cache = enabled;
+        self
+    }
+
+    pub fn with_cache_dir(mut self, cache_dir: impl Into<PathBuf>) -> Self {
+        self.cache_dir = cache_dir.into();
         self
     }
 }

--- a/crates/gear-mesh-generator/src/typescript.rs
+++ b/crates/gear-mesh-generator/src/typescript.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeSet;
 
 use gear_mesh_core::{
     EnumRepresentation, EnumType, FieldInfo, GearMeshType, NewtypeType, RenameRule, StructType,
-    TypeAttributes, TypeKind, TypeRef, VariantContent, to_typescript_primitive,
+    TypeAttributes, TypeKind, TypeRef, ValidationRule, VariantContent, to_typescript_primitive,
 };
 
 use crate::utils::{apply_rename_all, format_property_name, resolve_field_name};
@@ -72,7 +72,12 @@ impl TypeScriptGenerator {
         if self.config.generate_jsdoc
             && let Some(ref docs) = ty.docs
         {
-            self.output.push_str(&docs.to_jsdoc());
+            if self.config.enhanced_jsdoc {
+                self.output
+                    .push_str(&render_type_jsdoc(docs, &ty.name, self.config.generate_zod));
+            } else {
+                self.output.push_str(&docs.to_jsdoc());
+            }
             self.output.push('\n');
         }
 
@@ -129,13 +134,6 @@ impl TypeScriptGenerator {
         let indent = &self.config.indent;
 
         // フィールドのJSDoc
-        if self.config.generate_jsdoc
-            && let Some(ref docs) = field.docs
-        {
-            self.output
-                .push_str(&format!("{}{}\n", indent, docs.to_inline_jsdoc()));
-        }
-
         let field_name = format_property_name(&resolve_field_name(field, rename_all));
         let optional = if self.is_optional_field(field) {
             "?"
@@ -143,6 +141,24 @@ impl TypeScriptGenerator {
             ""
         };
         let ts_type = self.field_type_to_typescript(field);
+
+        if self.config.generate_jsdoc
+            && let Some(ref docs) = field.docs
+        {
+            if self.config.enhanced_jsdoc {
+                self.output.push_str(&render_field_jsdoc(
+                    indent,
+                    docs,
+                    &ts_type,
+                    optional == "?",
+                    &field.validations,
+                ));
+                self.output.push('\n');
+            } else {
+                self.output
+                    .push_str(&format!("{}{}\n", indent, docs.to_inline_jsdoc()));
+            }
+        }
 
         self.output.push_str(&format!(
             "{}{}{}: {};\n",
@@ -493,6 +509,118 @@ fn has_transformer_type(
             .any(|inner| has_transformer_type(inner, transformer))
 }
 
+fn render_type_jsdoc(
+    docs: &gear_mesh_core::DocComment,
+    name: &str,
+    include_schema_ref: bool,
+) -> String {
+    let mut lines = vec!["/**".to_string()];
+
+    if !docs.summary.is_empty() {
+        lines.push(format!(" * {}", docs.summary));
+    }
+
+    if let Some(description) = &docs.description {
+        lines.push(" *".to_string());
+        for line in description.lines() {
+            lines.push(format!(" * {}", line));
+        }
+    }
+
+    lines.push(" *".to_string());
+    lines.push(" * @remarks".to_string());
+    lines.push(" * This type is automatically generated from Rust.".to_string());
+    lines.push(" * Do not modify manually.".to_string());
+
+    if include_schema_ref {
+        lines.push(format!(
+            " * @see {{@link {}Schema}} for runtime validation",
+            name
+        ));
+    }
+
+    lines.push(" */".to_string());
+    lines.join("\n")
+}
+
+fn render_field_jsdoc(
+    indent: &str,
+    docs: &gear_mesh_core::DocComment,
+    ts_type: &str,
+    optional: bool,
+    validations: &[ValidationRule],
+) -> String {
+    let mut lines = vec![format!("{indent}/**")];
+
+    if !docs.summary.is_empty() {
+        lines.push(format!("{indent} * {}", docs.summary));
+    }
+
+    if let Some(description) = &docs.description {
+        lines.push(format!("{indent} *"));
+        for line in description.lines() {
+            lines.push(format!("{indent} * {}", line));
+        }
+    }
+
+    lines.push(format!("{indent} * @type {{{}}}", ts_type));
+    if optional {
+        lines.push(format!("{indent} * @optional"));
+    }
+
+    for tag in validation_tags(validations) {
+        lines.push(format!("{indent} * {}", tag));
+    }
+
+    lines.push(format!("{indent} */"));
+    lines.join("\n")
+}
+
+fn validation_tags(validations: &[ValidationRule]) -> Vec<String> {
+    let mut tags = Vec::new();
+
+    for rule in validations {
+        match rule {
+            ValidationRule::Range { min, max } => {
+                if let Some(min) = min {
+                    tags.push(format!("@minimum {}", min));
+                }
+                if let Some(max) = max {
+                    tags.push(format!("@maximum {}", max));
+                }
+            }
+            ValidationRule::Length { min, max } => {
+                if let Some(min) = min {
+                    tags.push(format!("@minLength {}", min));
+                }
+                if let Some(max) = max {
+                    tags.push(format!("@maxLength {}", max));
+                }
+            }
+            ValidationRule::Email => tags.push("@format email".to_string()),
+            ValidationRule::Url => tags.push("@format uri".to_string()),
+            ValidationRule::Pattern(pattern) => {
+                tags.push(format!("@pattern {}", sanitize_jsdoc_tag_value(pattern)))
+            }
+            ValidationRule::Required => tags.push("@required".to_string()),
+            ValidationRule::Custom { name, message } => {
+                tags.push(format!("@validation {}", sanitize_jsdoc_tag_value(name)));
+                if let Some(message) = message {
+                    tags.push(format!("@message {}", sanitize_jsdoc_tag_value(message)));
+                }
+            }
+            // Cross-field and conditional rules are emitted as object-level Zod refinements,
+            // so there is no stable field-level JSDoc tag representation for them here.
+            ValidationRule::CrossField { .. } | ValidationRule::Conditional { .. } => {}
+        }
+    }
+
+    tags
+}
+
+fn sanitize_jsdoc_tag_value(value: &str) -> String {
+    value.replace("*/", "*\\/").replace('\n', "\\n")
+}
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -588,7 +716,6 @@ mod tests {
             "(string | undefined)"
         );
     }
-
     #[test]
     fn test_custom_transformer_overrides_typescript_output() {
         let ty = GearMeshType {
@@ -617,5 +744,75 @@ mod tests {
 
         assert!(output.contains("import { DateTime } from 'luxon';"));
         assert!(output.contains("created_at: Date;"));
+    }
+
+    #[test]
+    fn test_enhanced_jsdoc_includes_type_and_validation_tags() {
+        let ty = GearMeshType {
+            name: "User".to_string(),
+            kind: TypeKind::Struct(StructType {
+                fields: vec![FieldInfo {
+                    name: "name".to_string(),
+                    ty: TypeRef::new("String"),
+                    docs: Some(gear_mesh_core::DocComment::summary("Display name")),
+                    validations: vec![ValidationRule::Length {
+                        min: Some(1),
+                        max: Some(20),
+                    }],
+                    optional: false,
+                    serde_attrs: Default::default(),
+                }],
+            }),
+            docs: Some(gear_mesh_core::DocComment::summary("User information")),
+            generics: vec![],
+            attributes: TypeAttributes::default(),
+        };
+
+        let mut generator = TypeScriptGenerator::new(
+            GeneratorConfig::new()
+                .with_zod(true)
+                .with_enhanced_jsdoc(true),
+        );
+        let output = generator.generate(&[ty]);
+
+        assert!(output.contains("@remarks"));
+        assert!(output.contains("@see {@link UserSchema}"));
+        assert!(output.contains("@type {string}"));
+        assert!(output.contains("@minLength 1"));
+        assert!(output.contains("@maxLength 20"));
+    }
+
+    #[test]
+    fn enhanced_jsdoc_sanitizes_comment_terminators_and_newlines() {
+        let ty = GearMeshType {
+            name: "RuleDoc".to_string(),
+            kind: TypeKind::Struct(StructType {
+                fields: vec![FieldInfo {
+                    name: "value".to_string(),
+                    ty: TypeRef::new("String"),
+                    docs: Some(gear_mesh_core::DocComment::summary("Docs")),
+                    validations: vec![
+                        ValidationRule::Pattern("foo*/bar".to_string()),
+                        ValidationRule::Custom {
+                            name: "line\nbreak".to_string(),
+                            message: Some("bad*/message".to_string()),
+                        },
+                    ],
+                    optional: false,
+                    serde_attrs: Default::default(),
+                }],
+            }),
+            docs: None,
+            generics: vec![],
+            attributes: TypeAttributes::default(),
+        };
+
+        let mut generator =
+            TypeScriptGenerator::new(GeneratorConfig::new().with_enhanced_jsdoc(true));
+        let output = generator.generate(&[ty]);
+
+        assert!(output.contains("@pattern foo*\\/bar"));
+        assert!(output.contains("@validation line\\nbreak"));
+        assert!(output.contains("@message bad*\\/message"));
     }
 }

--- a/crates/gear-mesh-generator/tests/property_tests.rs
+++ b/crates/gear-mesh-generator/tests/property_tests.rs
@@ -1,0 +1,95 @@
+use gear_mesh_generator::{
+    FieldInfo, GearMeshType, GeneratorConfig, StructType, TypeAttributes, TypeKind, TypeRef,
+    TypeScriptGenerator,
+};
+use proptest::prelude::*;
+
+fn arb_identifier() -> impl Strategy<Value = String> {
+    proptest::string::string_regex("[A-Z][A-Za-z0-9]{0,7}").unwrap()
+}
+
+fn arb_field_name() -> impl Strategy<Value = String> {
+    proptest::string::string_regex("[a-z][a-z0-9_]{0,7}").unwrap()
+}
+
+fn arb_type_ref() -> impl Strategy<Value = TypeRef> {
+    prop_oneof![
+        Just(TypeRef::new("String")),
+        Just(TypeRef::new("bool")),
+        Just(TypeRef::new("i32")),
+        Just(TypeRef::new("u64")),
+        Just(TypeRef::with_generics("Vec", vec![TypeRef::new("String")])),
+        Just(TypeRef::with_generics(
+            "Option",
+            vec![TypeRef::new("String")]
+        )),
+    ]
+}
+
+fn arb_gear_mesh_type() -> impl Strategy<Value = GearMeshType> {
+    (
+        arb_identifier(),
+        prop::collection::vec((arb_field_name(), arb_type_ref()), 1..4),
+    )
+        .prop_map(|(name, fields)| GearMeshType {
+            name,
+            kind: TypeKind::Struct(StructType {
+                fields: fields
+                    .into_iter()
+                    .map(|(field_name, ty)| FieldInfo {
+                        name: field_name,
+                        optional: ty.name == "Option",
+                        ty,
+                        docs: None,
+                        validations: vec![],
+                        serde_attrs: Default::default(),
+                    })
+                    .collect(),
+            }),
+            docs: None,
+            generics: vec![],
+            attributes: TypeAttributes::default(),
+        })
+}
+
+fn has_balanced_pairs(source: &str, open: char, close: char) -> bool {
+    let mut depth = 0isize;
+
+    for ch in source.chars() {
+        if ch == open {
+            depth += 1;
+        } else if ch == close {
+            depth -= 1;
+        }
+
+        if depth < 0 {
+            return false;
+        }
+    }
+
+    depth == 0
+}
+
+proptest! {
+    #[test]
+    fn generated_typescript_keeps_basic_syntax_invariants(ty in arb_gear_mesh_type()) {
+        let mut generator = TypeScriptGenerator::new(
+            GeneratorConfig::new().with_zod(true)
+        );
+        let output = generator.generate(&[ty]);
+
+        prop_assert_eq!(output.contains("export interface"), true);
+        prop_assert_eq!(has_balanced_pairs(&output, '{', '}'), true);
+        prop_assert_eq!(has_balanced_pairs(&output, '(', ')'), true);
+    }
+
+    #[test]
+    fn gear_mesh_type_roundtrips_through_json(ty in arb_gear_mesh_type()) {
+        let json = serde_json::to_string(&ty).unwrap();
+        let deserialized: GearMeshType = serde_json::from_str(&json).unwrap();
+        let reparsed = serde_json::to_value(deserialized).unwrap();
+        let original = serde_json::to_value(ty).unwrap();
+
+        prop_assert_eq!(original, reparsed);
+    }
+}

--- a/crates/gear-mesh/Cargo.toml
+++ b/crates/gear-mesh/Cargo.toml
@@ -11,6 +11,15 @@ repository.workspace = true
 keywords.workspace = true
 categories.workspace = true
 
+[features]
+default = []
+cli = ["dep:anyhow", "dep:clap", "dep:notify", "dep:serde", "dep:serde_json"]
+
+[[bin]]
+name = "gear-mesh"
+path = "src/bin/gear-mesh.rs"
+required-features = ["cli"]
+
 [dependencies]
 # Re-export all functionality from generator
 gear-mesh-generator = { workspace = true }
@@ -24,6 +33,12 @@ gear-mesh-derive = { workspace = true }
 # Automatic type collection
 inventory = "0.3"
 once_cell = "1.19"
+anyhow = { workspace = true, optional = true }
+clap = { workspace = true, optional = true }
+notify = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
+sha2 = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/crates/gear-mesh/src/bin/gear-mesh.rs
+++ b/crates/gear-mesh/src/bin/gear-mesh.rs
@@ -1,0 +1,124 @@
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::mpsc::channel;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use clap::{Parser, Subcommand};
+use notify::{Config, Event, RecommendedWatcher, RecursiveMode, Watcher};
+
+#[derive(Debug, Parser)]
+#[command(name = "gear-mesh")]
+#[command(about = "GearMesh developer tooling")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Debug, Subcommand)]
+enum Commands {
+    /// Diff two generated TypeScript files and emit a migration guide.
+    Diff {
+        old: PathBuf,
+        new: PathBuf,
+        #[arg(long)]
+        markdown: bool,
+    },
+    /// Watch paths and rerun a command when something changes.
+    Watch {
+        #[arg(long = "path", required = true)]
+        paths: Vec<PathBuf>,
+        #[arg(long, default_value_t = 250)]
+        debounce_ms: u64,
+        #[arg(trailing_var_arg = true, required = true)]
+        command: Vec<String>,
+    },
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::Diff { old, new, markdown } => diff_command(&old, &new, markdown),
+        Commands::Watch {
+            paths,
+            debounce_ms,
+            command,
+        } => watch_command(&paths, debounce_ms, &command),
+    }
+}
+
+fn diff_command(old: &PathBuf, new: &PathBuf, markdown: bool) -> Result<()> {
+    let old_source =
+        fs::read_to_string(old).with_context(|| format!("failed to read {}", old.display()))?;
+    let new_source =
+        fs::read_to_string(new).with_context(|| format!("failed to read {}", new.display()))?;
+    let report = gear_mesh::diff_typescript(&old_source, &new_source);
+
+    if markdown {
+        print!(
+            "{}",
+            report.to_markdown(&old.display().to_string(), &new.display().to_string())
+        );
+        return Ok(());
+    }
+
+    if report.is_empty() {
+        println!("No breaking changes detected.");
+        return Ok(());
+    }
+
+    for change in report.breaking_changes {
+        println!("BREAKING: {}", change);
+    }
+    for change in report.additions {
+        println!("ADDED: {}", change);
+    }
+
+    Ok(())
+}
+
+fn watch_command(paths: &[PathBuf], debounce_ms: u64, command: &[String]) -> Result<()> {
+    let (tx, rx) = channel();
+    let mut watcher = RecommendedWatcher::new(
+        move |event: notify::Result<Event>| {
+            let _ = tx.send(event);
+        },
+        Config::default(),
+    )?;
+
+    for path in paths {
+        watcher.watch(path, RecursiveMode::Recursive)?;
+    }
+
+    if let Err(err) = run_command(command) {
+        eprintln!("initial command failed: {err}");
+    }
+
+    loop {
+        match rx.recv() {
+            Ok(Ok(_)) => {
+                while rx.recv_timeout(Duration::from_millis(debounce_ms)).is_ok() {}
+                if let Err(err) = run_command(command) {
+                    eprintln!("watched command failed: {err}");
+                }
+            }
+            Ok(Err(err)) => eprintln!("watch error: {err}"),
+            Err(err) => return Err(err.into()),
+        }
+    }
+}
+
+fn run_command(command: &[String]) -> Result<()> {
+    let (program, args) = command
+        .split_first()
+        .context("watch command requires at least one argument")?;
+
+    let status = Command::new(program).args(args).status()?;
+    if !status.success() {
+        anyhow::bail!("watched command exited with {}", status);
+    }
+
+    Ok(())
+}

--- a/crates/gear-mesh/src/cache.rs
+++ b/crates/gear-mesh/src/cache.rs
@@ -1,0 +1,70 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct OutputCache {
+    entries: BTreeMap<String, String>,
+}
+
+impl OutputCache {
+    pub fn load(path: &Path) -> Self {
+        fs::read_to_string(path)
+            .ok()
+            .and_then(|content| serde_json::from_str(&content).ok())
+            .unwrap_or_default()
+    }
+
+    pub fn has_changed(&self, output_path: &Path, content: &str) -> bool {
+        let key = cache_key(output_path);
+        let hash = content_hash(content);
+        self.entries.get(&key) != Some(&hash)
+    }
+
+    pub fn update(&mut self, output_path: &Path, content: &str) {
+        self.entries
+            .insert(cache_key(output_path), content_hash(content));
+    }
+
+    pub fn persist(&self, path: &Path) -> std::io::Result<()> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        let body = serde_json::to_string_pretty(self)
+            .expect("OutputCache should always serialize to JSON");
+        fs::write(path, body)
+    }
+}
+
+pub fn cache_file(cache_dir: &Path) -> PathBuf {
+    cache_dir.join("outputs.json")
+}
+
+fn cache_key(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}
+
+fn content_hash(content: &str) -> String {
+    let digest = Sha256::digest(content.as_bytes());
+    format!("{digest:x}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_detects_content_changes() {
+        let path = Path::new("generated/user.ts");
+        let mut cache = OutputCache::default();
+
+        assert!(cache.has_changed(path, "v1"));
+        cache.update(path, "v1");
+        assert!(!cache.has_changed(path, "v1"));
+        assert!(cache.has_changed(path, "v2"));
+    }
+}

--- a/crates/gear-mesh/src/inventory_collect.rs
+++ b/crates/gear-mesh/src/inventory_collect.rs
@@ -63,14 +63,24 @@ pub fn generate_with_config(
         );
     }
 
-    let mut generator = crate::TypeScriptGenerator::new(config);
-    let output_content = generator.generate(&types);
-
+    let mut generator = crate::TypeScriptGenerator::new(config.clone());
+    let output = generator.generate(&types);
     let output_path = output_path.as_ref();
+
     if let Some(parent) = output_path.parent() {
         fs::create_dir_all(parent)?;
     }
-    fs::write(output_path, output_content)?;
+
+    let cache_path = crate::cache::cache_file(&config.cache_dir);
+    let mut cache = if config.enable_cache {
+        crate::cache::OutputCache::load(&cache_path)
+    } else {
+        crate::cache::OutputCache::default()
+    };
+    write_output(output_path, &output, config.enable_cache, &mut cache)?;
+    if config.enable_cache {
+        cache.persist(&cache_path)?;
+    }
 
     println!("✅ Generated TypeScript types: {}", output_path.display());
     println!("   {} types exported", types.len());
@@ -97,6 +107,12 @@ pub fn generate_types_to_dir_with_config(
     let organizer = crate::ModuleOrganizer::new(&types);
     let modules = organizer.organize(&types, &config.module_strategy);
     let type_index = organizer.build_type_index(&modules);
+    let cache_path = crate::cache::cache_file(&config.cache_dir);
+    let mut cache = if config.enable_cache {
+        crate::cache::OutputCache::load(&cache_path)
+    } else {
+        crate::cache::OutputCache::default()
+    };
 
     for (relative_path, module_types) in &modules {
         let file_path = output_dir.join(relative_path);
@@ -112,7 +128,7 @@ pub fn generate_types_to_dir_with_config(
         );
         let mut generator = crate::TypeScriptGenerator::new(config.clone());
         let content = generator.generate_with_imports(module_types, &imports);
-        fs::write(&file_path, content)?;
+        write_output(&file_path, &content, config.enable_cache, &mut cache)?;
         println!("  ✓ {}", relative_path);
     }
 
@@ -126,7 +142,17 @@ pub fn generate_types_to_dir_with_config(
             index_content.push_str(&format!("export * from './{}';\n", export_path));
         }
 
-        fs::write(output_dir.join("index.ts"), index_content)?;
+        write_output(
+            &output_dir.join("index.ts"),
+            &index_content,
+            config.enable_cache,
+            &mut cache,
+        )?;
+        println!("   📄 index.ts created");
+    }
+
+    if config.enable_cache {
+        cache.persist(&cache_path)?;
     }
 
     println!("✅ Generated TypeScript types to: {}", output_dir.display());
@@ -138,4 +164,24 @@ fn collect_registered_types() -> Vec<crate::GearMeshType> {
     inventory::iter::<TypeInfo>()
         .map(|info| (info.get_type)())
         .collect()
+}
+
+fn write_output(
+    path: &std::path::Path,
+    content: &str,
+    use_cache: bool,
+    cache: &mut crate::cache::OutputCache,
+) -> std::io::Result<()> {
+    use std::fs;
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    if !use_cache || cache.has_changed(path, content) || !path.exists() {
+        fs::write(path, content)?;
+        cache.update(path, content);
+    }
+
+    Ok(())
 }

--- a/crates/gear-mesh/src/lib.rs
+++ b/crates/gear-mesh/src/lib.rs
@@ -85,9 +85,12 @@ pub use gear_mesh_derive::GearMesh;
 pub use inventory;
 
 // Automatic type collection
+mod cache;
 mod inventory_collect;
+mod migration;
 pub use inventory_collect::{TypeInfo, generate_types, generate_types_to_dir};
 pub use inventory_collect::{generate_types_to_dir_with_config, generate_with_config};
+pub use migration::{MigrationReport, diff_typescript, parse_typescript_snapshot};
 
 // Output path registry for automatic generation
 mod output_registry;

--- a/crates/gear-mesh/src/migration.rs
+++ b/crates/gear-mesh/src/migration.rs
@@ -1,0 +1,264 @@
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, Default)]
+pub struct TypeScriptSnapshot {
+    pub interfaces: BTreeMap<String, InterfaceDef>,
+    pub aliases: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct InterfaceDef {
+    pub fields: BTreeMap<String, FieldDef>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FieldDef {
+    pub ty: String,
+    pub optional: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct MigrationReport {
+    pub breaking_changes: Vec<String>,
+    pub additions: Vec<String>,
+}
+
+impl MigrationReport {
+    pub fn is_empty(&self) -> bool {
+        self.breaking_changes.is_empty() && self.additions.is_empty()
+    }
+
+    pub fn to_markdown(&self, from_label: &str, to_label: &str) -> String {
+        let mut out = String::new();
+        out.push_str(&format!(
+            "# Migration Guide: {} -> {}\n\n",
+            from_label, to_label
+        ));
+
+        out.push_str("## Breaking Changes\n");
+        if self.breaking_changes.is_empty() {
+            out.push_str("- None detected\n");
+        } else {
+            for change in &self.breaking_changes {
+                out.push_str(&format!("- {}\n", change));
+            }
+        }
+
+        out.push_str("\n## Additions\n");
+        if self.additions.is_empty() {
+            out.push_str("- None detected\n");
+        } else {
+            for change in &self.additions {
+                out.push_str(&format!("- {}\n", change));
+            }
+        }
+
+        out
+    }
+}
+
+pub fn diff_typescript(old_source: &str, new_source: &str) -> MigrationReport {
+    let old_snapshot = parse_typescript_snapshot(old_source);
+    let new_snapshot = parse_typescript_snapshot(new_source);
+
+    let mut report = MigrationReport::default();
+
+    for (name, old_interface) in &old_snapshot.interfaces {
+        let Some(new_interface) = new_snapshot.interfaces.get(name) else {
+            report
+                .breaking_changes
+                .push(format!("Type `{}` was removed", name));
+            continue;
+        };
+
+        for (field, old_field) in &old_interface.fields {
+            let Some(new_field) = new_interface.fields.get(field) else {
+                report
+                    .breaking_changes
+                    .push(format!("`{}.{}` was removed", name, field));
+                continue;
+            };
+
+            if old_field.ty != new_field.ty {
+                report.breaking_changes.push(format!(
+                    "`{}.{}` changed from `{}` to `{}`",
+                    name, field, old_field.ty, new_field.ty
+                ));
+            }
+            if old_field.optional != new_field.optional {
+                report.breaking_changes.push(format!(
+                    "`{}.{}` changed optionality from `{}` to `{}`",
+                    name, field, old_field.optional, new_field.optional
+                ));
+            }
+        }
+
+        for field in new_interface.fields.keys() {
+            if !old_interface.fields.contains_key(field) {
+                report
+                    .additions
+                    .push(format!("`{}.{}` was added", name, field));
+            }
+        }
+    }
+
+    for name in new_snapshot.interfaces.keys() {
+        if !old_snapshot.interfaces.contains_key(name) {
+            report.additions.push(format!("Type `{}` was added", name));
+        }
+    }
+
+    for (name, old_alias) in &old_snapshot.aliases {
+        match new_snapshot.aliases.get(name) {
+            None => report
+                .breaking_changes
+                .push(format!("Type alias `{}` was removed", name)),
+            Some(new_alias) if new_alias != old_alias => report.breaking_changes.push(format!(
+                "Type alias `{}` changed from `{}` to `{}`",
+                name, old_alias, new_alias
+            )),
+            Some(_) => {}
+        }
+    }
+
+    for name in new_snapshot.aliases.keys() {
+        if !old_snapshot.aliases.contains_key(name) {
+            report
+                .additions
+                .push(format!("Type alias `{}` was added", name));
+        }
+    }
+
+    report
+}
+
+pub fn parse_typescript_snapshot(source: &str) -> TypeScriptSnapshot {
+    let mut snapshot = TypeScriptSnapshot::default();
+    let mut lines = source.lines().peekable();
+
+    while let Some(line) = lines.next() {
+        let trimmed = line.trim();
+        if let Some(body) = trimmed
+            .strip_prefix("export interface ")
+            .and_then(|rest| rest.strip_suffix(" {"))
+        {
+            let name = body.split('<').next().unwrap_or("").trim();
+            if name.is_empty() {
+                continue;
+            }
+            let mut interface = InterfaceDef::default();
+            for field_line in lines.by_ref() {
+                let trimmed = field_line.trim();
+                if trimmed == "}" {
+                    break;
+                }
+                if trimmed.starts_with("/**") || trimmed.starts_with('*') || trimmed.is_empty() {
+                    continue;
+                }
+
+                if let Some((field, ty)) = parse_field(trimmed) {
+                    interface.fields.insert(field, ty);
+                }
+            }
+            snapshot.interfaces.insert(name.to_string(), interface);
+            continue;
+        }
+
+        if let Some(rest) = trimmed.strip_prefix("export type ")
+            && let Some((name, body)) = rest.split_once(" = ")
+        {
+            snapshot.aliases.insert(
+                name.trim().to_string(),
+                body.trim_end_matches(';').trim().to_string(),
+            );
+        }
+    }
+
+    snapshot
+}
+
+fn parse_field(line: &str) -> Option<(String, FieldDef)> {
+    let normalized = line.trim_end_matches(';');
+    let (field, ty) = normalized.split_once(':')?;
+    let field = field.trim();
+    let optional = field.ends_with('?');
+    Some((
+        field.trim_end_matches('?').to_string(),
+        FieldDef {
+            ty: ty.trim().to_string(),
+            optional,
+        },
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn diff_detects_removed_and_changed_fields() {
+        let old_ts = r#"
+export interface User {
+    id: number;
+    email: string;
+}
+"#;
+        let new_ts = r#"
+export interface User {
+    id: number | null;
+}
+"#;
+
+        let report = diff_typescript(old_ts, new_ts);
+        assert!(
+            report
+                .breaking_changes
+                .contains(&"`User.id` changed from `number` to `number | null`".to_string())
+        );
+        assert!(
+            report
+                .breaking_changes
+                .contains(&"`User.email` was removed".to_string())
+        );
+    }
+
+    #[test]
+    fn diff_detects_optionality_changes() {
+        let old_ts = r#"
+export interface User {
+    name?: string;
+}
+"#;
+        let new_ts = r#"
+export interface User {
+    name: string;
+}
+"#;
+
+        let report = diff_typescript(old_ts, new_ts);
+        assert!(
+            report
+                .breaking_changes
+                .contains(&"`User.name` changed optionality from `true` to `false`".to_string())
+        );
+    }
+
+    #[test]
+    fn parser_handles_generic_interfaces() {
+        let source = r#"
+export interface ApiResponse<T> {
+    payload?: T;
+}
+"#;
+
+        let snapshot = parse_typescript_snapshot(source);
+        assert!(snapshot.interfaces.contains_key("ApiResponse"));
+        assert_eq!(
+            snapshot.interfaces["ApiResponse"].fields["payload"],
+            FieldDef {
+                ty: "T".to_string(),
+                optional: true,
+            }
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add a `gear-mesh` CLI with `diff` and `watch` commands for developer workflows
- add incremental output caching and migration diff reporting
- add opt-in enhanced JSDoc generation and property-based generator tests

## Verification
- cargo test

Closes #5
Closes #6
Closes #14
Closes #15
Closes #16